### PR TITLE
Add Page path to recent edits API

### DIFF
--- a/wiki/api/v1/endpoints/public.php
+++ b/wiki/api/v1/endpoints/public.php
@@ -86,6 +86,8 @@ trait PublicEndpoints
         $output = array();
         while ($edit = $edits->fetch_assoc())
         {
+            $page = $this->model->page->get(array('ID' => $edit['PageID']), "`Path`");
+            $edit['Path'] = $page->fetch_object()->Path;
             $output[] = $edit;
         }
 


### PR DESCRIPTION
Adds the page paths to the recent edits response, necessary for fishy to announce the page which was edited.