### PR TITLE
Use an explicit version for wetfish basic

### DIFF
--- a/wiki/src/package.json
+++ b/wiki/src/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "dragondrop": "^0.5.2",
     "load": "git://github.com/itsrachelfish/load",
-    "wetfish-basic": "^0.7.7"
+    "wetfish-basic": "0.7.7"
   }
 }


### PR DESCRIPTION
There is a bug in the latest version of wetfish basic preventing wiki pages from being edited