### PR TITLE
Use mime types, and exit early when files are corrupt

### DIFF
--- a/wiki/gallery.php
+++ b/wiki/gallery.php
@@ -35,7 +35,6 @@ $Pagination['is'] = 'On';
 $Pagination['Count'] = '30';
 
     # How many images per page?
-
     #
     # Friendship files
     ####################
@@ -105,7 +104,8 @@ foreach($Files as $File)
         if($Generate == 'Thumbnails')
         {
             if(!file_exists("$Path/{$Thumbnail['Directory']}/{$Thumbnail['Size']}_$File"))
-                ResizeImage("$Path/$Directory/$File", "$Path/{$Thumbnail['Directory']}/{$Thumbnail['Size']}_$File", $Thumbnail['Size']);
+		    if(!ResizeImage("$Path/$Directory/$File", "$Path/{$Thumbnail['Directory']}/{$Thumbnail['Size']}_$File", $Thumbnail['Size']))
+			    continue;
         }
 
         echo	"<div class='GalleryContainer'>

--- a/wiki/notgallery.php
+++ b/wiki/notgallery.php
@@ -29,7 +29,7 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 
 	$ImageData = @GetImageSize($Filename);
 	if ($ImageData == false)
-		return;
+		return false;
 	$Width = $ImageData[0];
 	$Height = $ImageData[1];
 
@@ -117,6 +117,7 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 	}
 
 	@chmod($Thumbnail, 0644);
+	return true;
 }
 
 function scandirByDate($dir)

--- a/wiki/notgallery.php
+++ b/wiki/notgallery.php
@@ -28,6 +28,8 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 	$Extension = $Path['extension'];
 
 	$ImageData = @GetImageSize($Filename);
+	if ($ImageData == false)
+		return;
 	$Width = $ImageData[0];
 	$Height = $ImageData[1];
 
@@ -49,12 +51,18 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 
 	$NewImage = @ImageCreateTrueColor($NewWidth, $NewHeight);
 
-	if(preg_match('/^gif$/i', $Extension))
-		$Image = @ImageCreateFromGif($Filename);
-	elseif(preg_match('/^png$/i', $Extension))
-		$Image = @ImageCreateFromPng($Filename);
-	else
-		$Image = @ImageCreateFromJpeg($Filename);
+	$Mime = mime_content_type($Filename);
+	switch ($Mime) {
+		case "image/gif":
+			$Image = @ImageCreateFromGif($Filename);
+			break;
+		case "image/png":
+			$Image = @ImageCreateFromPng($Filename);
+			break;
+		case "image/jpeg":
+			$Image = @ImageCreateFromJpeg($Filename);
+			break;
+	}
 
 	if($ImageData[2] == IMAGETYPE_GIF or $ImageData[2]  == IMAGETYPE_PNG)
 	{
@@ -92,17 +100,21 @@ function ResizeImage($Filename, $Thumbnail, $Size)
 			// Restore transparency blending
 			imagesavealpha($NewImage, true);
 		}
-    }
+	}
 
 	@ImageCopyResampled($NewImage, $Image, 0, 0, 0, 0, $NewWidth, $NewHeight, $Width, $Height);
 
-	if(preg_match('/^gif$/i', $Extension))
-		@ImageGif($NewImage, $Thumbnail);
-	elseif(preg_match('/^png$/i', $Extension))
-		@ImagePng($NewImage, $Thumbnail);
-	else
-		@ImageJpeg($NewImage, $Thumbnail);
-
+	switch ($Mime) {
+		case "image/gif":
+			@ImageGif($NewImage, $Thumbnail);
+			break;
+		case "image/png":
+			@ImagePng($NewImage, $Thumbnail);
+			break;
+		case "image/jpeg":
+			@ImageJpeg($NewImage, $Thumbnail);
+			break;
+	}
 
 	@chmod($Thumbnail, 0644);
 }


### PR DESCRIPTION
These changes will make ResizeImage return false on failure, which can happen when a file is corrupted. It also uses the mime type of the file to run the correct thumbnail generation