### PR TITLE
Fun feature: Allow embedded text files as either plain text or highlighted code

### DIFF
--- a/wiki/src/markup/view.php
+++ b/wiki/src/markup/view.php
@@ -513,7 +513,20 @@ function view_replacements($tag, $content)
 
                 return $Stuff;
             break;
-
+            case "text":
+                // I mean, I'm not great at this theming 
+                $content = file_get_contents($content);
+                $content = htmlspecialchars($content);
+                return "<pre style='font:monospace; background-color: #222; padding: 0.5rem;'><code>$content</code></pre>";
+            break;
+            case "code":
+                $content = file_get_contents($content);
+		$content = htmlspecialchars($content);
+                return "<link rel=\"stylesheet\" href=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/styles/default.min.css\">
+                <script src=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js\"></script>
+                <script>hljs.initHighlightingOnLoad()</script>
+                <pre style='margin: -3.5rem 0 -0.5rem 0;'><code>$content</pre></code>";
+            break;
             case "snow":
                 return '<script type="text/javascript" src="/snowstorm.js"></script>';
             break;


### PR DESCRIPTION
These additional views allow embedding of text uploads from the site. They can be used as follows:

```
text{upload/myhash.txt}
code{upload/myhash.txt}
```

Internally, the code element uses highlight.js, which is fetched on demand from cloudflare for higher locality, likeliness of cached status, and ease of maintenance. 
The text block is simply a `<pre><code>` element, ensuring that everything is html escaped. 

Before this is accepted, there is a possibility that we could add styling to the code blocks, since highlight.js facilitates that pretty trivially - we could do `code{upload/myhash.txt, stackoverflow-dark}` as an example. 