### PR TITLE
Allow localhost access to mysql

### DIFF
--- a/wiki/docker-compose.yml
+++ b/wiki/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     volumes:
       - ./src/schema.sql:/docker-entrypoint-initdb.d/setup.sql
       - dbdata:/var/lib/mysql
+    ports:
+      - "127.0.0.1:3306:3306"
     networks:
       - app-network
 


### PR DESCRIPTION
This was to facilitate testing for the deployment, but it is also useful on the Wiki for devs